### PR TITLE
[patch] Advance shared publisher workflow

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged == true && !contains(github.event.pull_request.title, 'skip-release')
-    uses: libops/.github/.github/workflows/bump-release.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed
+    uses: libops/.github/.github/workflows/bump-release.yaml@d5a29840172a53729c5999832534de65b7ba9587
     with:
       workflow_file: goreleaser.yaml
     permissions:

--- a/.github/workflows/lint-test-build-push.yaml
+++ b/.github/workflows/lint-test-build-push.yaml
@@ -119,14 +119,14 @@ jobs:
   publish:
     if: github.event_name != 'pull_request'
     needs: [lint-test]
-    uses: libops/.github/.github/workflows/build-push.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed # guarded-signed-image-publisher
+    uses: libops/.github/.github/workflows/build-push.yaml@d5a29840172a53729c5999832534de65b7ba9587 # guarded-signed-image-publisher
     with:
       ref: ${{ github.sha }}
       expected-main-sha: ${{ github.ref == 'refs/heads/main' && github.sha || '' }}
       additional-gar-registry: us-docker.pkg.dev/libops-images/public
       scan: true
       sign: true
-      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed
+      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@d5a29840172a53729c5999832534de65b7ba9587
     permissions:
       contents: read
       packages: write

--- a/publication_contract_test.go
+++ b/publication_contract_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-const sharedWorkflowSHA = "578137212ead4ab4059e95df17fa30e9b7ac4aed"
+const sharedWorkflowSHA = "d5a29840172a53729c5999832534de65b7ba9587"
 
 func readPublicationFile(t *testing.T, path string) string {
 	t.Helper()


### PR DESCRIPTION
Pins the release, image publication, and signing identity contracts to the reviewed cleanup-safe shared workflow revision.

No permissions or publication behavior are relaxed. Local actionlint, race tests, module verification, tidy diff, and publication contracts pass.