### PR TITLE
[patch] Align publisher with applied identity

### DIFF
--- a/.github/workflows/lint-test-build-push.yaml
+++ b/.github/workflows/lint-test-build-push.yaml
@@ -119,14 +119,14 @@ jobs:
   publish:
     if: github.event_name != 'pull_request'
     needs: [lint-test]
-    uses: libops/.github/.github/workflows/build-push.yaml@d5a29840172a53729c5999832534de65b7ba9587 # guarded-signed-image-publisher
+    uses: libops/.github/.github/workflows/build-push.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed # guarded-signed-image-publisher
     with:
       ref: ${{ github.sha }}
       expected-main-sha: ${{ github.ref == 'refs/heads/main' && github.sha || '' }}
       additional-gar-registry: us-docker.pkg.dev/libops-images/public
       scan: true
       sign: true
-      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@d5a29840172a53729c5999832534de65b7ba9587
+      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed
     permissions:
       contents: read
       packages: write

--- a/publication_contract_test.go
+++ b/publication_contract_test.go
@@ -6,7 +6,10 @@ import (
 	"testing"
 )
 
-const sharedWorkflowSHA = "d5a29840172a53729c5999832534de65b7ba9587"
+const (
+	sharedPublisherSHA = "578137212ead4ab4059e95df17fa30e9b7ac4aed"
+	sharedWorkflowSHA  = "d5a29840172a53729c5999832534de65b7ba9587"
+)
 
 func readPublicationFile(t *testing.T, path string) string {
 	t.Helper()
@@ -20,12 +23,12 @@ func readPublicationFile(t *testing.T, path string) string {
 func TestPublicationUsesReviewedSharedWorkflows(t *testing.T) {
 	publisher := readPublicationFile(t, ".github/workflows/lint-test-build-push.yaml")
 	for _, required := range []string{
-		"libops/.github/.github/workflows/build-push.yaml@" + sharedWorkflowSHA,
+		"libops/.github/.github/workflows/build-push.yaml@" + sharedPublisherSHA,
 		"additional-gar-registry: us-docker.pkg.dev/libops-images/public",
 		"expected-main-sha:",
 		"scan: true",
 		"sign: true",
-		"certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@" + sharedWorkflowSHA,
+		"certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@" + sharedPublisherSHA,
 	} {
 		if !strings.Contains(publisher, required) {
 			t.Errorf("publisher workflow must contain %q", required)


### PR DESCRIPTION
## Summary
- pin the signed dual-registry image publisher to the immutable shared-workflow revision already authorized by the applied WIF provider
- keep the certificate identity and publication contract tests aligned
- retain newer revisions for unrelated shared workflow callers

## Validation
- focused publication contract tests
- actionlint
- git diff --check