### PR TITLE
[patch] Restore applied publisher contract

### DIFF
--- a/.github/workflows/lint-test-build-push.yaml
+++ b/.github/workflows/lint-test-build-push.yaml
@@ -119,14 +119,14 @@ jobs:
   publish:
     if: github.event_name != 'pull_request'
     needs: [lint-test]
-    uses: libops/.github/.github/workflows/build-push.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed # guarded-signed-image-publisher
+    uses: libops/.github/.github/workflows/build-push.yaml@d5a29840172a53729c5999832534de65b7ba9587 # guarded-signed-image-publisher
     with:
       ref: ${{ github.sha }}
       expected-main-sha: ${{ github.ref == 'refs/heads/main' && github.sha || '' }}
       additional-gar-registry: us-docker.pkg.dev/libops-images/public
       scan: true
       sign: true
-      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed
+      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@d5a29840172a53729c5999832534de65b7ba9587
     permissions:
       contents: read
       packages: write

--- a/publication_contract_test.go
+++ b/publication_contract_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	sharedPublisherSHA = "578137212ead4ab4059e95df17fa30e9b7ac4aed"
+	sharedPublisherSHA = "d5a29840172a53729c5999832534de65b7ba9587"
 	sharedWorkflowSHA  = "d5a29840172a53729c5999832534de65b7ba9587"
 )
 


### PR DESCRIPTION
## Summary
- restore the cleanup-safe immutable shared publisher revision already authorized for Vault Proxy
- keep the signing certificate identity and contract test on that exact revision

## Validation
- Go publication contract tests
- actionlint
- git diff --check